### PR TITLE
Add support for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+jdk:
+  - oraclejdk8
+  - openjdk8
+
+install: true
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
     <description>Hadoop MapReduce tools for cleaning and re-organizing data that will be ingested into relational databases.</description>
 
     <properties>
+        <!-- Java Build Version -->
+        <java.version>1.8</java.version>
         <!-- Test dependencies -->
         <junit.version>5.0.0</junit.version>
     </properties>
@@ -19,11 +21,12 @@
         <testSourceDirectory>src/test/java</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.7.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
To add Travis CI test automation, a specific Java version was needed to be specified for building the project on Travis hardware. Java 8 has been arbitrarily chosen.