### PR TITLE
Add error handling to Int and Float Types

### DIFF
--- a/src/main/java/com/rw/legion/columncheck/FloatChecker.java
+++ b/src/main/java/com/rw/legion/columncheck/FloatChecker.java
@@ -33,11 +33,20 @@ public class FloatChecker implements ColumnChecker {
         }
     }
 
-    public FloatChecker(JsonObject json) {
+    public class InvalidFloatTypeException extends Exception {
+        public InvalidFloatTypeException(String message) {
+            super(message);
+        }
+    }
+
+    public FloatChecker(JsonObject json) throws InvalidFloatTypeException {
         if (! (json.has("floatType"))) {
             floatType = "double";
         } else {
             floatType = json.get("floatType").getAsString();
+            if (!floatType.equals("double") && !floatType.equals("float")) {
+                throw new InvalidFloatTypeException(floatType + " is not a valid floatType.");
+            }
         }
     }
 

--- a/src/main/java/com/rw/legion/columncheck/FloatChecker.java
+++ b/src/main/java/com/rw/legion/columncheck/FloatChecker.java
@@ -43,7 +43,7 @@ public class FloatChecker implements ColumnChecker {
         if (! (json.has("floatType"))) {
             floatType = "double";
         } else {
-            floatType = json.get("floatType").getAsString();
+            floatType = json.get("floatType").getAsString().toLowerCase();
             if (!floatType.equals("double") && !floatType.equals("float")) {
                 throw new InvalidFloatTypeException(floatType + " is not a valid floatType.");
             }

--- a/src/main/java/com/rw/legion/columncheck/IntegerChecker.java
+++ b/src/main/java/com/rw/legion/columncheck/IntegerChecker.java
@@ -27,8 +27,14 @@ import com.google.gson.JsonObject;
 public class IntegerChecker implements ColumnChecker {
     private int safeLength;
     private String intType;
+
+    public class InvalidIntTypeException extends Exception {
+        public InvalidIntTypeException(String message) {
+            super(message);
+        }
+    }
     
-    public IntegerChecker(JsonObject json) {
+    public IntegerChecker(JsonObject json) throws InvalidIntTypeException {
         if (! (json.has("intType"))) {
             intType = "int";
             safeLength = 9;
@@ -38,6 +44,9 @@ public class IntegerChecker implements ColumnChecker {
             if (intType.equals("short")) safeLength = 4;
             else if (intType.equals("int")) safeLength = 9;
             else if (intType.equals("long")) safeLength = 15;
+            else {
+                throw new InvalidIntTypeException(intType + " is not a valid Integer Type.");
+            }
         }
     }
     

--- a/src/main/java/com/rw/legion/columncheck/IntegerChecker.java
+++ b/src/main/java/com/rw/legion/columncheck/IntegerChecker.java
@@ -43,7 +43,7 @@ public class IntegerChecker implements ColumnChecker {
             
             if (intType.equals("short")) safeLength = 4;
             else if (intType.equals("int")) safeLength = 9;
-            else if (intType.equals("long")) safeLength = 15;
+            else if (intType.equals("long")) safeLength = 18;
             else {
                 throw new InvalidIntTypeException(intType + " is not a valid Integer Type.");
             }

--- a/src/main/java/com/rw/legion/columncheck/IntegerChecker.java
+++ b/src/main/java/com/rw/legion/columncheck/IntegerChecker.java
@@ -39,7 +39,7 @@ public class IntegerChecker implements ColumnChecker {
             intType = "int";
             safeLength = 9;
         } else {
-            intType = json.get("intType").getAsString();
+            intType = json.get("intType").getAsString().toLowerCase();
             
             if (intType.equals("short")) safeLength = 4;
             else if (intType.equals("int")) safeLength = 9;

--- a/src/test/java/com/rw/legion/columncheck/FloatCheckerTest.java
+++ b/src/test/java/com/rw/legion/columncheck/FloatCheckerTest.java
@@ -25,9 +25,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class FloatCheckerTest {
     private FloatChecker fcUnspecified;
+    private FloatChecker fcDoubleUpper;
     private FloatChecker fcDouble;
     private FloatChecker fcFloat;
 
+    private String floatTypeDoubleUpper = "DoUbLe";
     private String floatTypeDouble = "double";
     private String floatTypeFloat = "float";
     private String floatTypeInvalid = "foobar";
@@ -62,6 +64,7 @@ class FloatCheckerTest {
     @BeforeEach
     void setUp() throws FloatChecker.InvalidFloatTypeException {
         fcUnspecified = new FloatChecker(buildJson(null));
+        fcDoubleUpper = new FloatChecker(buildJson(floatTypeDoubleUpper));
         fcDouble = new FloatChecker(buildJson(floatTypeDouble));
         fcFloat = new FloatChecker(buildJson(floatTypeFloat));
     }
@@ -69,6 +72,11 @@ class FloatCheckerTest {
     @Test
     void throwsInvalidFloatTypeException() {
         assertThrows(FloatChecker.InvalidFloatTypeException.class, () -> new FloatChecker(buildJson(floatTypeInvalid)));
+    }
+
+    @Test
+    void validatesDoubleUpperVar() {
+        assertEquals(floatTypeDouble, fcDoubleUpper.getFloatType());
     }
 
     @Test

--- a/src/test/java/com/rw/legion/columncheck/FloatCheckerTest.java
+++ b/src/test/java/com/rw/legion/columncheck/FloatCheckerTest.java
@@ -30,6 +30,7 @@ class FloatCheckerTest {
 
     private String floatTypeDouble = "double";
     private String floatTypeFloat = "float";
+    private String floatTypeInvalid = "foobar";
 
     private static String maxDouble = Double.toString(Double.MAX_VALUE);  // 1.7976931348623157E308
     private static String minDouble = Double.toString(Double.MIN_VALUE);  // 4.9E-324
@@ -59,10 +60,15 @@ class FloatCheckerTest {
         return obj;
     }
     @BeforeEach
-    void setUp() {
+    void setUp() throws FloatChecker.InvalidFloatTypeException {
         fcUnspecified = new FloatChecker(buildJson(null));
         fcDouble = new FloatChecker(buildJson(floatTypeDouble));
         fcFloat = new FloatChecker(buildJson(floatTypeFloat));
+    }
+
+    @Test
+    void throwsInvalidFloatTypeException() {
+        assertThrows(FloatChecker.InvalidFloatTypeException.class, () -> new FloatChecker(buildJson(floatTypeInvalid)));
     }
 
     @Test

--- a/src/test/java/com/rw/legion/columncheck/IntegerCheckerTest.java
+++ b/src/test/java/com/rw/legion/columncheck/IntegerCheckerTest.java
@@ -38,7 +38,7 @@ class IntegerCheckerTest {
 
     private int safeLengthShort = 4;
     private int safeLengthInt = 9;
-    private int safeLengthLong = 15;
+    private int safeLengthLong = 18;
 
     private String validShort = "1234";
     private String validShortNeg = "-1234";

--- a/src/test/java/com/rw/legion/columncheck/IntegerCheckerTest.java
+++ b/src/test/java/com/rw/legion/columncheck/IntegerCheckerTest.java
@@ -25,10 +25,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class IntegerCheckerTest {
     private IntegerChecker icUnspecified;
+    private IntegerChecker icShortUpper;
     private IntegerChecker icShort;
     private IntegerChecker icInt;
     private IntegerChecker icLong;
 
+    private String intTypeShortUpper = "ShOrT";
     private String intTypeShort = "short";
     private String intTypeInt = "int";
     private String intTypeLong = "long";
@@ -68,6 +70,7 @@ class IntegerCheckerTest {
     @BeforeEach
     void setUp() throws IntegerChecker.InvalidIntTypeException {
         icUnspecified = new IntegerChecker(buildJson(null));
+        icShortUpper = new IntegerChecker(buildJson(intTypeShortUpper));
         icShort = new IntegerChecker(buildJson(intTypeShort));
         icInt = new IntegerChecker(buildJson(intTypeInt));
         icLong = new IntegerChecker(buildJson(intTypeLong));
@@ -76,6 +79,12 @@ class IntegerCheckerTest {
     @Test
     void throwsInvalidIntTypeException() {
         assertThrows(IntegerChecker.InvalidIntTypeException.class, () -> new IntegerChecker(buildJson(intTypeInvalid)));
+    }
+
+    @Test
+    void validatesShortUpperVars() {
+        assertEquals(intTypeShort, icShortUpper.getIntType());
+        assertEquals(safeLengthShort, icShortUpper.getSafeLength());
     }
 
     @Test

--- a/src/test/java/com/rw/legion/columncheck/IntegerCheckerTest.java
+++ b/src/test/java/com/rw/legion/columncheck/IntegerCheckerTest.java
@@ -32,6 +32,7 @@ class IntegerCheckerTest {
     private String intTypeShort = "short";
     private String intTypeInt = "int";
     private String intTypeLong = "long";
+    private String intTypeInvalid = "fooBar";
 
     private int safeLengthShort = 4;
     private int safeLengthInt = 9;
@@ -65,11 +66,16 @@ class IntegerCheckerTest {
     }
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IntegerChecker.InvalidIntTypeException {
         icUnspecified = new IntegerChecker(buildJson(null));
         icShort = new IntegerChecker(buildJson(intTypeShort));
         icInt = new IntegerChecker(buildJson(intTypeInt));
         icLong = new IntegerChecker(buildJson(intTypeLong));
+    }
+
+    @Test
+    void throwsInvalidIntTypeException() {
+        assertThrows(IntegerChecker.InvalidIntTypeException.class, () -> new IntegerChecker(buildJson(intTypeInvalid)));
     }
 
     @Test


### PR DESCRIPTION
Previously, it is possible to not catch invalid int/float types. Additionally, these types were case sensitive.

This patch removes case sensitivity requirement and appropriately handles Exception throwing when an invalid numeric type is provided.

Previously, the safe length of a Long was set to 15, but the max long value (`9,223,372,036,854,775,807`) actually has a safe length of 18.

Tests are included.