### PR TITLE
Update license badge to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/republicwireless-open/legion.svg?branch=master)](https://travis-ci.org/republicwireless-open/legion)
 [![CodeCov](https://codecov.io/gh/republicwireless-open/legion/branch/master/graph/badge.svg)](https://codecov.io/gh/republicwireless-open/legion)
-[![GitHub license](https://img.shields.io/badge/license-apache-blue.svg)](https://github.com/republicwireless-open/legion/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/republicwireless-open/legion/blob/master/LICENSE)
 
 ## Summary
 


### PR DESCRIPTION
Updating License Badge to Apache 2.0 since that's the actual license version